### PR TITLE
Convert banner to clickable Link 

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,5 @@
 # Welcome to ClueLess Community.
-![1ad7db43-d819-4dd7-8ead-0ea3cca39b2f](https://user-images.githubusercontent.com/91758830/193335357-7907fc11-09d6-4bdf-8e57-5f850d74f85d.jpg)
+[![How to get eligible for swags?](https://user-images.githubusercontent.com/91758830/193335357-7907fc11-09d6-4bdf-8e57-5f850d74f85d.jpg)](https://clueless-resources.super.site/hacktoberfest/how-to-get-eligible-for-swags)
 
 ---
 


### PR DESCRIPTION
After clicking on the banner, it just opens the image instead of that we can redirect the user to the  [this article](https://clueless-resources.super.site/hacktoberfest/how-to-get-eligible-for-swags)!